### PR TITLE
Patched TensorFlow Type Error

### DIFF
--- a/cache_decorator/backends/keras_model_backend.py
+++ b/cache_decorator/backends/keras_model_backend.py
@@ -65,5 +65,9 @@ try:
                     tar_handle.extractall(tmpdirname)
                 return load_model(tmpdirname, **self._load_kwargs)
 
-except ModuleNotFoundError:
+# We need to check both for `ModuleNotFoundError`, where
+# simply the TensorFlow package is not installed, and
+# a more obscure `TypeError` caused by occasional internal
+# errors of TensorFlow when it is not properly installed.
+except (ModuleNotFoundError, TypeError):
     KerasModelBackend = None

--- a/cache_decorator/backends/pandas_csv_backend.py
+++ b/cache_decorator/backends/pandas_csv_backend.py
@@ -91,7 +91,8 @@ try:
             for column in obj_to_serialize.columns:
                 if not is_consistent(obj_to_serialize[column]):
                     warnings.warn("The column '{}'".format(
-                        column) + common_message)
+                        column
+                    ) + common_message)
 
             if not is_consistent(obj_to_serialize.index):
                 warnings.warn("The index" + common_message)


### PR DESCRIPTION
This is a patch to resolve issues where TensorFlow installations fail:

```python
/opt/conda/lib/python3.9/site-packages/ensmallen/datasets/get_okapi_tfidf_weighted_textual_embedding.py in <module>
      4 import numpy as np
      5 import pandas as pd
----> 6 from cache_decorator import Cache
      7 
      8 from ensmallen import preprocessing

/opt/conda/lib/python3.9/site-packages/cache_decorator/__init__.py in <module>
      1 """Package that automatically caches and dispatch serialization and deserialization to the correct functions depending on the extension."""
----> 2 from .cache import Cache, cache
      3 from .backends import SerializationException, DeserializationException
      4 
      5 import logging

/opt/conda/lib/python3.9/site-packages/cache_decorator/cache.py in <module>
     21     get_next_format_group, get_function_name,
     22 )
---> 23 from .backends import Backend
     24 
     25 # Dictionary are not hashable and the python hash is not consistent

/opt/conda/lib/python3.9/site-packages/cache_decorator/backends/__init__.py in <module>
      1 """Package with all the serialization and deserializzation functions for each extension."""
      2 
----> 3 from .backend import Backend
      4 from .exceptions import SerializationException, DeserializationException
      5 

/opt/conda/lib/python3.9/site-packages/cache_decorator/backends/backend.py in <module>
     13 from .pandas_embedding_backend import PandasEmbeddingBackend
     14 from .numpy_backend import NumpyBackend
---> 15 from .keras_model_backend import KerasModelBackend
     16 
     17 from .exceptions import SerializationException, DeserializationException

/opt/conda/lib/python3.9/site-packages/cache_decorator/backends/keras_model_backend.py in <module>
      7 
      8 try:
----> 9     from tensorflow.keras.models import Model, save_model, load_model
     10 
     11     def create_tar(src_dir, tar_file, extension):

/opt/conda/lib/python3.9/site-packages/tensorflow/__init__.py in <module>
     35 import typing as _typing
     36 
---> 37 from tensorflow.python.tools import module_util as _module_util
     38 from tensorflow.python.util.lazy_loader import LazyLoader as _LazyLoader
     39 

/opt/conda/lib/python3.9/site-packages/tensorflow/python/__init__.py in <module>
     35 
     36 from tensorflow.python import pywrap_tensorflow as _pywrap_tensorflow
---> 37 from tensorflow.python.eager import context
     38 
     39 # pylint: enable=wildcard-import

/opt/conda/lib/python3.9/site-packages/tensorflow/python/eager/context.py in <module>
     27 import six
     28 
---> 29 from tensorflow.core.framework import function_pb2
     30 from tensorflow.core.protobuf import config_pb2
     31 from tensorflow.core.protobuf import coordination_config_pb2

/opt/conda/lib/python3.9/site-packages/tensorflow/core/framework/function_pb2.py in <module>
      5 import sys
      6 _b=sys.version_info[0]<3 and (lambda x:x) or (lambda x:x.encode('latin1'))
----> 7 from google.protobuf import descriptor as _descriptor
      8 from google.protobuf import message as _message
      9 from google.protobuf import reflection as _reflection

/opt/conda/lib/python3.9/site-packages/google/protobuf/descriptor.py in <module>
     38 import warnings
     39 
---> 40 from google.protobuf.internal import api_implementation
     41 
     42 _USE_C_DESCRIPTORS = False

/opt/conda/lib/python3.9/site-packages/google/protobuf/internal/api_implementation.py in <module>
    102   try:
    103     # pylint: disable=g-import-not-at-top
--> 104     from google.protobuf.pyext import _message
    105     _c_module = _message
    106     del _message

TypeError: bases must be types
```