### PR TITLE
Removed warning

### DIFF
--- a/cache_decorator/backends/pandas_csv_backend.py
+++ b/cache_decorator/backends/pandas_csv_backend.py
@@ -26,6 +26,8 @@ try:
         if series.dtype != "object":
             return True
 
+        
+
         expected_type = str(type(series.values[0]))
         return all(
             expected_type == str(type(s))
@@ -87,12 +89,6 @@ try:
             return PandasCsvBackend.support_path(path) and isinstance(obj_to_serialize, pd.DataFrame)
 
         def dump(self, obj_to_serialize: pd.DataFrame, path: str) -> dict:
-
-            for column in obj_to_serialize.columns:
-                if not is_consistent(obj_to_serialize[column]):
-                    warnings.warn("The column '{}'".format(
-                        column
-                    ) + common_message)
 
             if not is_consistent(obj_to_serialize.index):
                 warnings.warn("The index" + common_message)


### PR DESCRIPTION
The warning in question is already entirely handled by the restoration of types present below. The type restore, when it fails, already raises a `NotImplementedError`.